### PR TITLE
docs(saas-app): replace rbm with saas app

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  title: 'Recurring Billing Module by Prestashop',
+  title: 'SaaS App by Prestashop',
   description: '',
   theme: 'api',
   head: [

--- a/docs/0-overview/README.md
+++ b/docs/0-overview/README.md
@@ -5,7 +5,7 @@ title: Overview
 
 # ![](/assets/images/common/logo-condensed-sm.png) Overview
 
-Recurring Billing Modules allow Tech Partners and Sellers to create SaaS modules integrated within the PrestaShop ecosystem with a simple and unified onboarding for Merchants.
+SaaS App allow Tech Partners and Sellers to create SaaS modules integrated within the PrestaShop ecosystem with a simple and unified onboarding for Merchants.
 
 Subscriptions are managed and billed by the PrestaShop Billing system which pays back the module creator through an automatic monthly payment.
 
@@ -13,7 +13,7 @@ Subscriptions are managed and billed by the PrestaShop Billing system which pays
 
 ## Building a SaaS App
 
-The creation of a Recurring Billing Module requires to interract with PsAccount and PsBilling.
+The creation of a SaaS App requires to interract with PsAccount and PsBilling.
 
 ![SaaS App fully initialized](/assets/images/0-overview/rbm_fully_initialized.png)
 
@@ -35,7 +35,7 @@ PsAccount designate a tool suite to link a PrestaShop Module with the PrestaShop
 
 ### PsBilling
 
-PsBilling designate a tool suite to manage merchant subscription to your recurring billing module. PsBilling is composed by:
+PsBilling designate a tool suite to manage merchant subscription to your SaaS App. PsBilling is composed by:
 
 - The Billing API wich store the subscription
 - A frontend component required into your module's configuration page. this component is splitted in 2 main part: the merchant subscription panel, and the funnel modal

--- a/docs/2-saas-app/README.md
+++ b/docs/2-saas-app/README.md
@@ -1,12 +1,12 @@
 ---
-title: Recurring Billing Module
+title: SaaS App
 ---
 
 <Block>
 
-# ![](/assets/images/common/logo-condensed-sm.png) Recurring Billing Module
+# ![](/assets/images/common/logo-condensed-sm.png) SaaS App
 
-A recurring Billing Module is a composition of [PHP](https://www.php.net/) as backend and [Vue 2](https://vuejs.org/) as frontend.
+A SaaS App is a composition of [PHP](https://www.php.net/) as backend and [Vue 2](https://vuejs.org/) as frontend.
 
 ::: tip
 In the future Vue 2 may not be required as the PrestaShop Billing Component doesn't require it.
@@ -14,7 +14,7 @@ In the future Vue 2 may not be required as the PrestaShop Billing Component does
 
 Here is the step to create a SaaS App :
 
-1. Create a PrestaShop Module
+1. [Create a PrestaShop Module](https://devdocs.prestashop.com/1.7/modules/)
 2. Make the PHP part injecting the proper `context` in the `window` object, which is required for PsAccount and PsBilling.
 3. Create a JS app including PsAccount and PsBilling
 4. Inject the `context` in PsAccount and PsBilling
@@ -119,7 +119,7 @@ It will be useful for afterwards
 #### PsAccount
 
 ::: warning Requirement
-Recurring Billing Modules require PsAccount to be installed on the shop in order to work.
+SaaS App require PsAccount to be installed on the shop in order to work.
 :::
 
 ##### Load PsAccount utility
@@ -640,7 +640,7 @@ yarn add prestashop_accounts_vue_components
 The `PsAccount` front component is loaded by the CDN in the smarty template.
 
 ::: warning Use the CDN
-CDN is the proper way to implement a recurring billing module, you should use only the npm dependency as a fallback in case the CDN doesn't work properly
+CDN is the proper way to implement a SaaS App, you should use only the npm dependency as a fallback in case the CDN doesn't work properly
 :::
 
 ```html

--- a/docs/4-setup-dev-environment/README.md
+++ b/docs/4-setup-dev-environment/README.md
@@ -24,7 +24,7 @@ For more information about localhost.run, CF the [official doc](http://localhost
 
 **Step 1**: create a classic PrestaShop module, please CF the [official doc](https://devdocs.prestashop.com/1.7/modules/creation/tutorial/)
 
-**Step 2**: convert the module into [SaaS App module](../1-recurring-billing-module/README.md)
+**Step 2**: convert the module into [SaaS App module](../2-saas-app/README.md)
 
 An example of SaaS App module is also available for [reference](https://github.com/PrestaShopCorp/prestashop_rbm_example)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 ---
 home: true
-title: Recurring Billing Module by PrestaShop
-description: Not sure where to start? We’ve put together some handy guides and reference documentation you can use to start building a Recurring Billing Module for PrestaShop.
+title: SaaS App by PrestaShop
+description: Not sure where to start? We’ve put together some handy guides and reference documentation you can use to start building a SaaS App Module for PrestaShop.
 actionText: Getting Started
 actionLink: /0-overview
 footer: Made by [@PrestaShop](https://addons.prestashop.com/), Power by [vuepress](https://github.com/vuejs/vuepress).


### PR DESCRIPTION
Replacing "recurring billing module" by "SaaS App" in the documentation